### PR TITLE
Fix add-port for Docker nodes

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -280,7 +280,7 @@ function connectInterface($n, $p, $nodeType) {
 	// Make sure bridge exists before adding port
 	if (isOvs($n)) {
 		if($nodeType == 'docker') {
-			$cmd = 'ovs-vsctl add-port '.$n.' '.$p.' -- set interface '.$p.' type=internal 2>&1';
+			$cmd = 'ovs-vsctl --may-exist add-port '.$n.' '.$p.' -- set interface '.$p.' type=internal 2>&1';
 		} else {
 			$cmd = 'ovs-vsctl --may-exist add-port '.$n.' '.$p.' 2>&1';
 		}


### PR DESCRIPTION
## Fix the add-port command for Docker nodes in the connectInterface method.

### Summary:
**Before, I was getting this error:** cannot create a port named vunl2_5_0 because a port named vunl2_5_0 already exists on bridge pnet1
```
tail -100f /opt/unetlab/data/Logs/unl_wrapper.txt
Jan 12 13:57:23 INFO: Adding Network vnet2_1 pnet1
Jan 12 13:57:23 INFO: Is Cloud pnet1
Jan 12 13:57:23 INFO: starting docker -H=tcp://127.0.0.1:4243 start a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5
Jan 12 13:57:23 INFO: CWD is /opt/unetlab/tmp/2/a281ec3d-c78b-4111-b4f7-61ff48a1e8d4/5
Jan 12 13:57:23 INFO: starting docker -H=tcp://127.0.0.1:4243 start a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5
Jan 12 13:57:23 INFO: started rc 0
Jan 12 13:57:23 INFO: started output ["a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5"]
Jan 12 13:57:23 INFO: adding port to ovs ovs-vsctl add-port pnet1 vunl2_5_0 -- set interface vunl2_5_0 type=internal 2>&1
Jan 12 13:57:23 ERROR: Cannot add interface to OVS (80031).
Jan 12 13:57:23 ovs-vsctl: cannot create a port named vunl2_5_0 because a port named vunl2_5_0 already exists on bridge pnet1
Jan 12 13:57:23 Jan 12 13:57:23 ERROR: Cannot add interface to OVS (80031).
Jan 12 13:57:23 Jan 12 13:57:23 ERROR: Failed to start node (12).
```

**With the fix, it's OK**
```
tail -100f /opt/unetlab/data/Logs/unl_wrapper.txt
Jan 12 13:58:43 INFO: Adding Network vnet2_1 pnet1
Jan 12 13:58:43 INFO: Is Cloud pnet1
Jan 12 13:58:43 INFO: starting docker -H=tcp://127.0.0.1:4243 start a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5
Jan 12 13:58:43 INFO: CWD is /opt/unetlab/tmp/2/a281ec3d-c78b-4111-b4f7-61ff48a1e8d4/5
Jan 12 13:58:43 INFO: starting docker -H=tcp://127.0.0.1:4243 start a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5
Jan 12 13:58:44 INFO: started rc 0
Jan 12 13:58:44 INFO: started output ["a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5"]
Jan 12 13:58:44 INFO: adding port to ovs ovs-vsctl --may-exist add-port pnet1 vunl2_5_0 -- set interface vunl2_5_0 type=internal 2>&1
Jan 12 13:58:44 INFO: importing nohup /opt/unetlab/scripts/config_docker.py -a put -i a281ec3d-c78b-4111-b4f7-61ff48a1e8d4-2-5 -f /opt/unetlab/tmp/2/a281ec3d-c78b-4111-b4f7-61ff48a1e8d4/5/startup-config -t 300 > /dev/null 2>&1 &
```

